### PR TITLE
usersにroleを追加

### DIFF
--- a/database/migrations/2025_02_27_152038_add_role_to_users_table.php
+++ b/database/migrations/2025_02_27_152038_add_role_to_users_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    /**
+     * usersテーブルに管理者を識別するためのroleを追加する
+     * tinyintは小さい数字を扱うための型
+     * unsigned ：マイナスを使わない
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->tinyInteger('role')->unsigned();
+            //
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+            //
+        });
+    }
+};


### PR DESCRIPTION
@sirowabisuke @enmusubi22 @hnk2326 
usersテーブルに管理者権限のroleを追加するマイグレーションファイルを追加しました。

プルができたらターミナルで

php artisan php migrate

を実行してデータベースを作りなおしてください。
添付の画像のようにusersテーブル内にroleが入っていればいいと思います。
![role_table](https://github.com/user-attachments/assets/651a977c-2f19-4c30-86f9-e014ea470d9a)