### PR TITLE
商品一覧画面（検索機能それぞれ単独で実装済み、ページネーション・ダミーデータ設定済み）

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Item;
+use Illuminate\Http\Request;
+
+class CategoryController extends Controller
+{
+    public function index(Request $request)
+    {
+        // セレクトボックスから送られた値を取得
+        $categoryId = $request->input('category');
+
+        // 検索処理
+        $query = Item::query(); // Productモデルのインスタンスを作成
+
+        $message = "検索キーワードを入力してください。"; // item検索の表示のため
+
+        if (in_array($categoryId, [1, 2, 3, 4])) {
+            // カテゴリが選択されている場合の検索
+            $query->where('category_id', $categoryId);
+            $items = $query->paginate(10)->withQueryString(); // 検索結果を取得
+            $totalPrice = Item::where('category_id', $categoryId)->sum('price');
+        } else {
+        // ページネーションとクエリ文字列を保持
+        $items = $query->paginate(10)->withQueryString();
+        $totalPrice = Item::all()->sum('price');
+        }
+
+        // 検索結果をビューに渡す
+        return view('items.index', compact('items', 'message', 'totalPrice'));
+    }
+}

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -27,19 +27,26 @@ class ItemController extends Controller
             ->orWhere('date', 'like', '%' .$search. '%')
             ->orWhere('price', 'like', '%' .$search. '%')
             ->orWhere('detail', 'like', '%' .$search. '%');
-
+        $totalPrice = Item::where('item_name', 'like', '%' .$search. '%') // 
+            ->orWhere('id', 'like', '%' .$search. '%')
+            ->orWhere('user_id', 'like', '%' .$search. '%')
+            ->orWhere('date', 'like', '%' .$search. '%')
+            ->orWhere('price', 'like', '%' .$search. '%')
+            ->orWhere('detail', 'like', '%' .$search. '%')
+            ->sum('price');
         } else {     // 未入力の場合
             $message = "検索キーワードを入力してください。";
             // 未入力なら、全データ表示
             $items = Item::all();
+            $totalPrice = Item::all()->sum('price');
         }
           // 変数を一つ受け渡す場合はcompact関数又はwithメソッドで送信。
 
-          $items = $query->orderBy('date')->get();
+          $items = $query->orderBy('date')->paginate(10)->withQueryString();
 
           // compactの方が可読性が高いのでそちらを使うことが多い。
-      return view('items.index', compact('search', 'query', 'message', 'items'));
-      // view側では通常の変数名で展開可能  {{ $message }}    
+        return view('items.index', compact('search', 'query', 'message', 'items', 'totalPrice'));
+        // view側では通常の変数名で展開可能  {{ $message }}    
 
     }
 

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -22,8 +22,8 @@ class Item extends Model
     ];
 
     protected $casts = [  // 型変換
-        'created_at' => 'datetime:Y-m-d',
-        'updated_at' => 'datetime:Y-m-d',
+        'created_at' => 'datetime:Y/m/d',
+        'updated_at' => 'datetime:Y/m/d',
     ];
 
     // 所属テーブルから主テーブルへの関係を定義するときに使う

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Pagination\Paginator;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +20,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Paginator::useBootstrapFive();
+        Paginator::useBootstrapFour();
     }
 }

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Category>
+ */
+class CategoryFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/ItemFactory.php
+++ b/database/factories/ItemFactory.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Item;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Item>
+ */
+class ItemFactory extends Factory
+{
+    protected $model = Item::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        // item_nameのリスト
+        $items = [
+             ['name' => 'アイロン', 'category_id' => 3, 'detail' => 'しわをきれいに伸ばせるアイロン'],
+             ['name' => 'インスタントラーメン', 'category_id' => 1, 'detail' => '手軽に作れる美味しいラーメン'],
+             ['name' => 'お好み焼き粉', 'category_id' => 1, 'detail' => '手軽に美味しいお好み焼きが作れる粉'],
+             ['name' => 'お茶', 'category_id' => 1, 'detail' => '上品な香りの緑茶'],
+             ['name' => 'クッキー', 'category_id' => 1, 'detail' => 'バター風味でサクサクのクッキー'],
+             ['name' => 'コーヒー豆', 'category_id' => 1, 'detail' => '香り高いコーヒー豆'],
+             ['name' => 'ジャガイモ', 'category_id' => 1, 'detail' => '国産'],
+             ['name' => 'ジュース', 'category_id' => 1, 'detail' => '果汁100%のジュース'],
+             ['name' => 'ジュース', 'category_id' => 1, 'detail' => 'フレッシュな果汁100%のジュース'],
+             ['name' => 'ソース', 'category_id' => 1, 'detail' => '濃い味わいで料理にぴったりなソース'],
+             ['name' => 'チーズ', 'category_id' => 1, 'detail' => 'まろやかで濃厚なチーズ'],
+             ['name' => 'チョコレート', 'category_id' => 1, 'detail' => '甘くて濃厚なチョコレート'],
+             ['name' => 'ティッシュ', 'category_id' => 2, 'detail' => 'しっかりとした使い心地'],
+             ['name' => 'トイレットペーパー', 'category_id' => 2, 'detail' => '経済的で長持ちするトイレットペーパー'],
+             ['name' => 'ハム', 'category_id' => 1, 'detail' => '贅沢な味わいのスライスハム'],
+             ['name' => 'パン', 'category_id' => 1, 'detail' => '焼きたてのふわふわパン'],
+             ['name' => 'ビスケット', 'category_id' => 1, 'detail' => 'サクサクとした食感のビスケット'],
+             ['name' => 'フライパン', 'category_id' => 3, 'detail' =>  '軽量で使いやすいフライパン'],
+             ['name' => 'フランスパン', 'category_id' => 1, 'detail' => '焼きたてのフランスパン'],
+             ['name' => 'ポット', 'category_id' => 3, 'detail' =>  '温かい飲み物を長時間保温'],
+             ['name' => 'マスク', 'category_id' => 2, 'detail' => '快適に使える高性能マスク'],
+             ['name' => 'まな板', 'category_id' => 3, 'detail' =>  '抗菌加工が施されたまな板'],
+             ['name' => 'マヨネーズ', 'category_id' => 1, 'detail' => '濃厚でクリーミーなマヨネーズ'],
+             ['name' => 'ミキサー', 'category_id' => 3, 'detail' =>  'スムージー作りに便利なミキサー'],
+             ['name' => 'ヨーグルト', 'category_id' => 1, 'detail' => '乳酸菌たっぷりのヨーグルト'],
+             ['name' => '果物', 'category_id' => 1, 'detail' => '旬のフルーツ'],
+             ['name' => '歯ブラシ', 'category_id' => 2,'detail' => '磨きやすいデザインで歯に優しい'],
+             ['name' => '除湿機', 'category_id' => 4, 'detail' =>  '湿気を取る優れた除湿機'],
+             ['name' => '洗剤', 'category_id' => 2, 'detail' => '洗浄力が強く、環境にも優しい'],
+             ['name' => '電気ケトル', 'category_id' => 3, 'detail' =>  '1リットルの容量で短時間でお湯が沸く'],
+             ['name' => '豆腐', 'category_id' => 1, 'detail' => '栄養満点な国産豆腐'],
+             ['name' => '肉', 'category_id' => 1, 'detail' => '国産＆輸入品'],
+             ['name' => '肉', 'category_id' => 1, 'detail' => '国産'],
+             ['name' => '納豆', 'category_id' => 1, 'detail' => '	健康に良い納豆'],
+             ['name' => '米' , 'category_id' => 1, 'detail' => '高品質な国内産のお米'],
+             ['name' => '米', 'category_id' => 1, 'detail' => '国内産のお米'],
+             ['name' => '野菜', 'category_id' => 1, 'detail' => '有機野菜'],
+             ['name' => '野菜', 'category_id' => 1, 'detail' => '国産野菜']
+        ];
+
+        // item_name をランダムに選ぶ
+        $item = $this->faker->randomElement($items);
+
+        return [
+            'category_id' => $item['category_id'],
+            'user_id' => User::inRandomOrder()->first()->id ?? 1,  // 'user_id' => 1, // 必要ならランダムなユーザーIDに変更
+            'date' => Carbon::now()->subDays(rand(1, 30)), // 過去30日間のランダムな日付
+            'item_name' => $item['name'],
+            'price' => $this->faker->numberBetween(100, 10000),
+            'detail' => $item['detail'], // item_name に応じた detail を設定
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use App\Models\Item;
 
 class DatabaseSeeder extends Seeder
 {
@@ -12,6 +13,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+        
+        // アイテムを50件作成
+        Item::factory(50)->create();
+
         // \App\Models\User::factory(10)->create();
 
         // \App\Models\User::factory()->create([

--- a/database/seeders/ItemSeeder.php
+++ b/database/seeders/ItemSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Item;
+use Illuminate\Support\Facades\DB;
+
+class ItemSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // IDをリセットしてからダミーデータを作成
+        DB::table('items')->truncate(); 
+
+        Item::factory()->count(50)->create(); // 50件のダミーデータを作成
+    }
+}

--- a/resources/views/items/index.blade.php
+++ b/resources/views/items/index.blade.php
@@ -1,89 +1,95 @@
-@extends('items.layout')
+@extends('layouts.app')<!-- サイドバー -->
 
 @section('content')
-<div class="container">
+<div class="container px-5 text-bg-warning-emphasis bg-warning-subtle p-3">    
 
-    <div class="balance">
-        <h3>商品情報一覧</h3>
-        <div class="items">
-            <h5>商品一覧</h5>
-            <div class="w-25 p-0">
-                <!-- セレクトボックスを設置 --> 
-                <form action="index" method="GET">
-                {{ csrf_field() }}          <!-- CSRFトークン -->
-                    <select class="form-select-success form-select-sm mb-3" aria-label=".form-select-sm example" name="category">
-                        <option selected>カテゴリ検索</option>
-                        <option value="1" >1</option>
-                        <option value="2" >2</option>
-                        <option value="3" >3</option>
-                        <option value="4" >4</option>
-                    </select>
-                    <button type="submit">検索</button>
-                </form>
+<!-- 商品情報一覧 -->
+    <h5>商品一覧</h5>
+    <div class="items">
+        <div class="p-0">
+            <div class="text-end">
+                <a href="create" class="btn btn-primary-emphasis bg-primary-subtle">商品新規登録</a>
             </div>
-            
-            <div class="input-group">
-                <!-- <div>検索</div> -->
-                <p>{{ $message }}</p>
-            </div>
-            <form class="">
+        </div>
+            <form action="index" method="GET" class="">
+                <div class="input-group">
+
+                <!-- 検索 -->
+                    <p class="mb-1">{{ $message }}</p>
+                </div>
                 <div class="col">
                 @include('items.search')<!-- 検索フォーム -->
                 @if($items->isEmpty())
                     <p>検索結果が見つかりませんでした。</p>
                 @else
-                <div class="d-flex flex-row-reverse">
-                        <a href="create" class="btn btn-primary mb-3">商品新規登録</a>
-                </div>
-                    <table class="table table-striped" border="1">
-                        <thead>
-                            <tr>
-                                <th>カテゴリ </th>
-                                <th>ID</th>
-                                <th>USER_ID</th>
-                                <th>購入日</th>
-                                <th>商品名</th>
-                                <th>金額</th>
-                                <th>詳細</th>
-                                <th>登録日</th>
-                                <th>更新日</th>
-                                <th></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        @foreach ($items as $item)
-                            <tr>
-                                <td>{{ $item->category_id }}</td>
-                                <td>{{ $item->id }}</td>
-                                <td>{{ $item->user_id }}</td>
-                                <td>{{ $item->date }}</td>
-                                <td>{{ $item->item_name }}</td>
-                                <td>{{ $item->price }}</td>
-                                <td>{{ $item->detail }}</td>
-                                <td>{{ $item->created_at }}</td>
-                                <td>{{ $item->updated_at }}</td>
-                                <td>
-                                    <div class="action-buttons">
-                                        <a href="edit/{{$item->id}}" class="btn btn-success" style="padding: 2px 16px;">編集</a>
-                                        <form method="POST" action="destroy/{{$item->id}}" style="display:inline;">
-                                            @csrf
-                                            @method('DELETE')
-                                            <button type="submit" class="btn btn-danger" style="padding: 2px 16px;" onclick="return confirm('削除しますか？')">削除</button>
-                                        </form>
-                                    </div>
-                                </td>
-                            </tr>
-                        @endforeach
-                        </tbody>
-                    </table>
-                    
-                    <!-- ページネーション -->
-                    
+                    <!-- セレクトボックスを設置 --> 
+                    <form action="category" method="GET">
+                    {{ csrf_field() }}          <!-- CSRFトークン -->
+                        <select class="form-select-success form-select-sm mb-3" aria-label=".form-select-sm example" name="category">
+                            <option selected>カテゴリ検索</option>
+                            <option value="1" >1</option>
+                            <option value="2" >2</option>
+                            <option value="3" >3</option>
+                            <option value="4" >4</option>
+                        </select>
+                        <button type="submit" class="btn btn-outline-secondary" style="padding: 2px 10px;">検索</button>
+                    </form>
+                        <div class="overflow-x-auto text-nowrap ">
+                            <table class="table table-striped" border="1">
+                                <thead>
+                                    <tr>
+                                        <th>カテゴリ </th>
+                                        <th>ID</th>
+                                        <th>USER_ID</th>
+                                        <th>購入日</th>
+                                        <th>商品名</th>
+                                        <th>金額</th>
+                                        <th>詳細</th>
+                                        <th>登録日</th>
+                                        <th>更新日</th>
+                                        <th></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                @foreach ($items as $item)
+                                    <tr>
+                                        <td>{{ $item->category_id }}</td>
+                                        <td>{{ $item->id }}</td>
+                                        <td>{{ $item->user_id }}</td>
+                                        <td>{{ $item->date }}</td>
+                                        <td>{{ $item->item_name }}</td>
+                                        <td>{{ $item->price }}</td>
+                                        <td>{{ $item->detail }}</td>
+                                        <td>{{ $item->created_at->format('Y/m/d') }}</td>
+                                        <td>{{ $item->updated_at->format('Y/m/d') }}</td>
+                                        <td>
+                                            <div class="action-buttons">
+                                                <a href="edit/{{$item->id}}" class="btn btn-success-emphasis bg-success-subtle" style="padding: 2px 16px;">編集</a>
+                                                <form method="POST" action="destroy/{{$item->id}}" style="display:inline;">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="btn btn-danger-emphasis bg-danger-subtle" style="padding: 2px 16px;" onclick="return confirm('削除しますか？')">削除</button>
+                                                </form>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                                </tbody>
+                            </table>
+                        </div>
                 @endif
-                </div>
-            </form>
-        </div>     
-    </div>
+                </div>    
 
+            </form>
+            <div class="d-flex justify-content-between">
+                <div class="">        
+                <!-- ページネーションリンクを表示 -->
+                {{ $items->links('pagination::item') }}
+                </div>
+                <div class="">
+                    <p>合計：{{ number_format($totalPrice) }}円</p>
+                </div>
+            </div>
+    </div>
 </div>
 @endsection

--- a/resources/views/items/search.blade.php
+++ b/resources/views/items/search.blade.php
@@ -4,7 +4,7 @@
     {{ csrf_field() }}          <!-- CSRFトークン -->
         <div class="row gy-0 gx-3 align-items-center">
             <div class="col-md-2">
-                <label for="formGroupExampleInput" class="form-label">キーワード：　</label>
+                <label for="formGroupExampleInput" class="d-flex flex-row-reverse">キーワード：</label>
             </div>
             <div class="col-md-4">
                 <input type="text" name="search" value="{{ request('search') }}" class="form-control" id="formGroupExampleInput" placeholder="キーワードで検索できます">

--- a/resources/views/vendor/pagination/bootstrap-4.blade.php
+++ b/resources/views/vendor/pagination/bootstrap-4.blade.php
@@ -1,0 +1,46 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                    <span class="page-link" aria-hidden="true">&lsaquo;</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</a>
+                </li>
+            @endif
+
+            {{-- Pagination Elements --}}
+            @foreach ($elements as $element)
+                {{-- "Three Dots" Separator --}}
+                @if (is_string($element))
+                    <li class="page-item disabled" aria-disabled="true"><span class="page-link">{{ $element }}</span></li>
+                @endif
+
+                {{-- Array Of Links --}}
+                @if (is_array($element))
+                    @foreach ($element as $page => $url)
+                        @if ($page == $paginator->currentPage())
+                            <li class="page-item active" aria-current="page"><span class="page-link">{{ $page }}</span></li>
+                        @else
+                            <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
+                        @endif
+                    @endforeach
+                @endif
+            @endforeach
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                    <span class="page-link" aria-hidden="true">&rsaquo;</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/bootstrap-5.blade.php
+++ b/resources/views/vendor/pagination/bootstrap-5.blade.php
@@ -1,0 +1,88 @@
+@if ($paginator->hasPages())
+    <nav class="d-flex justify-items-center justify-content-between">
+        <div class="d-flex justify-content-between flex-fill d-sm-none">
+            <ul class="pagination">
+                {{-- Previous Page Link --}}
+                @if ($paginator->onFirstPage())
+                    <li class="page-item disabled" aria-disabled="true">
+                        <span class="page-link">@lang('pagination.previous')</span>
+                    </li>
+                @else
+                    <li class="page-item">
+                        <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">@lang('pagination.previous')</a>
+                    </li>
+                @endif
+
+                {{-- Next Page Link --}}
+                @if ($paginator->hasMorePages())
+                    <li class="page-item">
+                        <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">@lang('pagination.next')</a>
+                    </li>
+                @else
+                    <li class="page-item disabled" aria-disabled="true">
+                        <span class="page-link">@lang('pagination.next')</span>
+                    </li>
+                @endif
+            </ul>
+        </div>
+
+        <div class="d-none flex-sm-fill d-sm-flex align-items-sm-center justify-content-sm-between">
+            <div>
+                <p class="small text-muted">
+                    {!! __('Showing') !!}
+                    <span class="fw-semibold">{{ $paginator->firstItem() }}</span>
+                    {!! __('to') !!}
+                    <span class="fw-semibold">{{ $paginator->lastItem() }}</span>
+                    {!! __('of') !!}
+                    <span class="fw-semibold">{{ $paginator->total() }}</span>
+                    {!! __('results') !!}
+                </p>
+            </div>
+
+            <div>
+                <ul class="pagination">
+                    {{-- Previous Page Link --}}
+                    @if ($paginator->onFirstPage())
+                        <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                            <span class="page-link" aria-hidden="true">&lsaquo;</span>
+                        </li>
+                    @else
+                        <li class="page-item">
+                            <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</a>
+                        </li>
+                    @endif
+
+                    {{-- Pagination Elements --}}
+                    @foreach ($elements as $element)
+                        {{-- "Three Dots" Separator --}}
+                        @if (is_string($element))
+                            <li class="page-item disabled" aria-disabled="true"><span class="page-link">{{ $element }}</span></li>
+                        @endif
+
+                        {{-- Array Of Links --}}
+                        @if (is_array($element))
+                            @foreach ($element as $page => $url)
+                                @if ($page == $paginator->currentPage())
+                                    <li class="page-item active" aria-current="page"><span class="page-link">{{ $page }}</span></li>
+                                @else
+                                    <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
+                                @endif
+                            @endforeach
+                        @endif
+                    @endforeach
+
+                    {{-- Next Page Link --}}
+                    @if ($paginator->hasMorePages())
+                        <li class="page-item">
+                            <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                        </li>
+                    @else
+                        <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                            <span class="page-link" aria-hidden="true">&rsaquo;</span>
+                        </li>
+                    @endif
+                </ul>
+            </div>
+        </div>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/default.blade.php
+++ b/resources/views/vendor/pagination/default.blade.php
@@ -1,0 +1,46 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                    <span aria-hidden="true">&lsaquo;</span>
+                </li>
+            @else
+                <li>
+                    <a href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</a>
+                </li>
+            @endif
+
+            {{-- Pagination Elements --}}
+            @foreach ($elements as $element)
+                {{-- "Three Dots" Separator --}}
+                @if (is_string($element))
+                    <li class="disabled" aria-disabled="true"><span>{{ $element }}</span></li>
+                @endif
+
+                {{-- Array Of Links --}}
+                @if (is_array($element))
+                    @foreach ($element as $page => $url)
+                        @if ($page == $paginator->currentPage())
+                            <li class="active" aria-current="page"><span>{{ $page }}</span></li>
+                        @else
+                            <li><a href="{{ $url }}">{{ $page }}</a></li>
+                        @endif
+                    @endforeach
+                @endif
+            @endforeach
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li>
+                    <a href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                </li>
+            @else
+                <li class="disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                    <span aria-hidden="true">&rsaquo;</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/item.blade.php
+++ b/resources/views/vendor/pagination/item.blade.php
@@ -1,0 +1,50 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="{{ __('Pagination Navigation') }}" class="flex items-center justify-between mt-2">
+        <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between mt-1">
+            <div>
+                <p class="text-sm text-gray-700 leading-5 dark:text-gray-400 mb-2">
+                    <span class="font-medium">{{ $paginator->total() . '件中　' }}</span>
+                    {!! __('') !!}
+                    @if ($paginator->firstItem())
+                        <span class="font-medium">{{ $paginator->firstItem() . '件' }}</span>
+                        {!! __('～') !!}
+                        <span class="font-medium">{{ $paginator->lastItem() . '件' }}</span>
+                    @else
+                        {{ $paginator->count() }}
+                    @endif
+                    {!! __('') !!}
+                    {!! __('表示') !!}
+                </p>
+            </div>
+
+            <div>
+                <span class="relative z-0 inline-flex rtl:flex-row-reverse shadow-sm rounded-md">
+
+                    {{-- Pagination Elements --}}
+                    @foreach ($elements as $element)
+                        {{-- "Three Dots" Separator --}}
+                        @if (is_string($element))
+                            <span aria-disabled="true">
+                                <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 cursor-default leading-5 dark:bg-gray-800 dark:border-gray-600">{{ $element }}</span>
+                            </span>
+                        @endif
+
+                        {{-- Array Of Links --}}
+                        @if (is_array($element))
+                            @foreach ($element as $page => $url)
+                                @if ($page == $paginator->currentPage())
+                                    <span aria-current="page">
+                                        <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 dark:bg-gray-800 dark:border-gray-600">{{ $page }}</span>
+                                    </span>
+                                @else
+                                    <a href="{{ $url }}" class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 hover:text-gray-500 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400 dark:hover:text-gray-300 dark:active:bg-gray-700 dark:focus:border-blue-800" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">
+                                        {{ $page }}
+                                    </a>
+                                @endif
+                            @endforeach
+                        @endif
+                    @endforeach
+            </div>
+        </div>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/semantic-ui.blade.php
+++ b/resources/views/vendor/pagination/semantic-ui.blade.php
@@ -1,0 +1,36 @@
+@if ($paginator->hasPages())
+    <div class="ui pagination menu" role="navigation">
+        {{-- Previous Page Link --}}
+        @if ($paginator->onFirstPage())
+            <a class="icon item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')"> <i class="left chevron icon"></i> </a>
+        @else
+            <a class="icon item" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')"> <i class="left chevron icon"></i> </a>
+        @endif
+
+        {{-- Pagination Elements --}}
+        @foreach ($elements as $element)
+            {{-- "Three Dots" Separator --}}
+            @if (is_string($element))
+                <a class="icon item disabled" aria-disabled="true">{{ $element }}</a>
+            @endif
+
+            {{-- Array Of Links --}}
+            @if (is_array($element))
+                @foreach ($element as $page => $url)
+                    @if ($page == $paginator->currentPage())
+                        <a class="item active" href="{{ $url }}" aria-current="page">{{ $page }}</a>
+                    @else
+                        <a class="item" href="{{ $url }}">{{ $page }}</a>
+                    @endif
+                @endforeach
+            @endif
+        @endforeach
+
+        {{-- Next Page Link --}}
+        @if ($paginator->hasMorePages())
+            <a class="icon item" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')"> <i class="right chevron icon"></i> </a>
+        @else
+            <a class="icon item disabled" aria-disabled="true" aria-label="@lang('pagination.next')"> <i class="right chevron icon"></i> </a>
+        @endif
+    </div>
+@endif

--- a/resources/views/vendor/pagination/simple-bootstrap-4.blade.php
+++ b/resources/views/vendor/pagination/simple-bootstrap-4.blade.php
@@ -1,0 +1,27 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">@lang('pagination.previous')</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">@lang('pagination.previous')</a>
+                </li>
+            @endif
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">@lang('pagination.next')</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">@lang('pagination.next')</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/simple-bootstrap-5.blade.php
+++ b/resources/views/vendor/pagination/simple-bootstrap-5.blade.php
@@ -1,0 +1,29 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="Pagination Navigation">
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">{!! __('pagination.previous') !!}</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">
+                        {!! __('pagination.previous') !!}
+                    </a>
+                </li>
+            @endif
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">{!! __('pagination.next') !!}</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">{!! __('pagination.next') !!}</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/simple-default.blade.php
+++ b/resources/views/vendor/pagination/simple-default.blade.php
@@ -1,0 +1,19 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="disabled" aria-disabled="true"><span>@lang('pagination.previous')</span></li>
+            @else
+                <li><a href="{{ $paginator->previousPageUrl() }}" rel="prev">@lang('pagination.previous')</a></li>
+            @endif
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li><a href="{{ $paginator->nextPageUrl() }}" rel="next">@lang('pagination.next')</a></li>
+            @else
+                <li class="disabled" aria-disabled="true"><span>@lang('pagination.next')</span></li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/simple-tailwind.blade.php
+++ b/resources/views/vendor/pagination/simple-tailwind.blade.php
@@ -1,0 +1,25 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="Pagination Navigation" class="flex justify-between">
+        {{-- Previous Page Link --}}
+        @if ($paginator->onFirstPage())
+            <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-800 dark:border-gray-600">
+                {!! __('pagination.previous') !!}
+            </span>
+        @else
+            <a href="{{ $paginator->previousPageUrl() }}" rel="prev" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+                {!! __('pagination.previous') !!}
+            </a>
+        @endif
+
+        {{-- Next Page Link --}}
+        @if ($paginator->hasMorePages())
+            <a href="{{ $paginator->nextPageUrl() }}" rel="next" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+                {!! __('pagination.next') !!}
+            </a>
+        @else
+            <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-800 dark:border-gray-600">
+                {!! __('pagination.next') !!}
+            </span>
+        @endif
+    </nav>
+@endif

--- a/resources/views/vendor/pagination/tailwind.blade.php
+++ b/resources/views/vendor/pagination/tailwind.blade.php
@@ -1,0 +1,106 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="{{ __('Pagination Navigation') }}" class="flex items-center justify-between mt-2">
+        <div class="flex justify-between flex-1 sm:hidden">
+            @if ($paginator->onFirstPage())
+                <span class="relative inline-flex items-center px-3 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-800 dark:border-gray-600">
+                    {!! __('前ページ') !!}
+                </span>
+            @else
+                <a href="{{ $paginator->previousPageUrl() }}" class="relative inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+                    {!! __('前ページ') !!}
+                </a>
+            @endif
+
+            @if ($paginator->hasMorePages())
+                <a href="{{ $paginator->nextPageUrl() }}" class="relative inline-flex items-center px-3 py-2 ml-3 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+                    {!! __('次ページ') !!}
+                </a>
+            @else
+                <span class="relative inline-flex items-center px-3 py-2 ml-3 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-800 dark:border-gray-600">
+                    {!! __('次ページ') !!}
+                </span>
+            @endif
+        </div>
+
+        <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between mt-1">
+            <div>
+                <p class="text-sm text-gray-700 leading-5 dark:text-gray-400">
+                    <span class="font-medium">{{ $paginator->total() . '件中　' }}</span>
+                    {!! __('') !!}
+                    @if ($paginator->firstItem())
+                        <span class="font-medium">{{ $paginator->firstItem() . '件' }}</span>
+                        {!! __('～') !!}
+                        <span class="font-medium">{{ $paginator->lastItem() . '件' }}</span>
+                    @else
+                        {{ $paginator->count() }}
+                    @endif
+                    {!! __('') !!}
+                    {!! __('表示') !!}
+                </p>
+            </div>
+
+            <div>
+                <span class="relative z-0 inline-flex rtl:flex-row-reverse shadow-sm rounded-md">
+                    {{-- Previous Page Link --}}
+                    @if ($paginator->onFirstPage())
+                        <span aria-disabled="true" aria-label="{{ __('pagination.previous') }}">
+                            <span class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-l-md leading-5 dark:bg-gray-800 dark:border-gray-600" aria-hidden="true">
+                                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+                                </svg>
+                            </span>
+                        </span>
+                    @else
+                        <a href="{{ $paginator->previousPageUrl() }}" rel="prev" class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-l-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:active:bg-gray-700 dark:focus:border-blue-800" aria-label="{{ __('pagination.previous') }}">
+                            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+                            </svg>
+                        </a>
+                    @endif
+
+                    {{-- Pagination Elements --}}
+                    @foreach ($elements as $element)
+                        {{-- "Three Dots" Separator --}}
+                        @if (is_string($element))
+                            <span aria-disabled="true">
+                                <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 cursor-default leading-5 dark:bg-gray-800 dark:border-gray-600">{{ $element }}</span>
+                            </span>
+                        @endif
+
+                        {{-- Array Of Links --}}
+                        @if (is_array($element))
+                            @foreach ($element as $page => $url)
+                                @if ($page == $paginator->currentPage())
+                                    <span aria-current="page">
+                                        <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 dark:bg-gray-800 dark:border-gray-600">{{ $page }}</span>
+                                    </span>
+                                @else
+                                    <a href="{{ $url }}" class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 hover:text-gray-500 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400 dark:hover:text-gray-300 dark:active:bg-gray-700 dark:focus:border-blue-800" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">
+                                        {{ $page }}
+                                    </a>
+                                @endif
+                            @endforeach
+                        @endif
+                    @endforeach
+
+                    {{-- Next Page Link --}}
+                    @if ($paginator->hasMorePages())
+                        <a href="{{ $paginator->nextPageUrl() }}" rel="next" class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-r-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:active:bg-gray-700 dark:focus:border-blue-800" aria-label="{{ __('pagination.next') }}">
+                            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                            </svg>
+                        </a>
+                    @else
+                        <span aria-disabled="true" aria-label="{{ __('pagination.next') }}">
+                            <span class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-r-md leading-5 dark:bg-gray-800 dark:border-gray-600" aria-hidden="true">
+                                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                                </svg>
+                            </span>
+                        </span>
+                    @endif
+                </span>
+            </div>
+        </div>
+    </nav>
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,8 @@ use App\Http\Controllers\User\UserRegisterController;
 // 商品一覧画面
 Route::get('/index', [App\Http\Controllers\ItemController::class, 'index']);
 
+Route::get('/category', [App\Http\Controllers\CategoryController::class, 'index']);
+// Route::get('/', [App\Http\Controllers\ItemController::class, 'index']);
 // http://127.0.0.1:8000 から表示される画面をログイン画面にする
 Route::get('/', function () {
     return view('/auth.login');


### PR DESCRIPTION
@enmusubi22 @hnk2326 @hiroshi-t-1400 
商品一覧画面をプルリクエストしました。
・サイドバーをindex.blade.phpに読み込み画面を調整しました。
・キーワードとカテゴリの検索機能。
（別々での検索になります。例えば、カテゴリ"1番"の中の"米"は検索できません。ホーム画面の画像が終わり、時間が取れれば　調べてみようと思います。）
・ページネーション（デザインは少ないですが他にもあります。viewsフォルダにvendorフォルダができていますが、ページネーションデザインが決まり次第ほとんどを削除する予定です。）
・ダミーデータをデータベースにコマンドで登録できます。
コマンドは、　”php artisan db:seed --class=ItemSeeder”　です。itemsテーブルのみに50件ランダムに登録されます。idはその都度"1"から始まります。category_idはすべて"1"になっています。