### PR TITLE
認証機能で修正、主に画面遷移

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -31,6 +31,8 @@ class AuthController extends Controller
         // もう一度ログインをする必要はないので、操作ミスということにしてホーム画面へリダイレクト・遷移させる
 
         // [月森]　念のため実装を見送ります
+
+        // session()->flash('message', 'すでにログインしています。');
         // $this->middleware('guest');
     }
 
@@ -55,14 +57,20 @@ class AuthController extends Controller
 
         // ログイン操作が短時間に繰り返されたときの危険回避
         // Auth::attempt 取得した情報と今のログインユーザーの情報を照らし合わせる
+        //
+        // (03/08)思い違いをしていました
+        // Auth::attempt でデータベースの情報とリクエストされた情報を照合し
+        // 合致していたらtrue → ログインするための ifコードを実行
+        // でなければ falseで ifをスキップ
         if (Auth::attempt(['email' => $request->email, 'password' => $request->password])) {
             // ブラウザのセッション情報を再生成(regenerate)して、ログインしようとする動作をリセットする
             $request->session()->regenerate();
             // ログイン後の画面に遷移させる
-            return redirect()->intended('home');
+            // return redirect()->intended('home'); 都合が悪いので変更します。（月森
+            return redirect('home');
         }
 
-        // ユーザー情報のメールアドレスが間違っていたらエラーエラーメッセージを表示させる
+        // ユーザー情報のメールアドレスかパスワードが間違っていたらエラーメッセージを表示させる
         return back()->withErrors([
             'email' => '入力された登録情報が間違っています。',
         ]);

--- a/app/Http/Controllers/User/UserRegisterController.php
+++ b/app/Http/Controllers/User/UserRegisterController.php
@@ -62,9 +62,8 @@ class UserRegisterController extends Controller
             'role' => $request->role,
         ]);
 
-        // ToDo：アカウント認証ログイン機能を実装したらこコメント外す
         // アカウント作成に成功したらそのままログインする、の一行
-        // Auth::login($user);
+        Auth::login($user);
 
         // ホーム画面に遷移する
         return redirect('home');

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -12,6 +12,7 @@ class Authenticate extends Middleware
      */
     protected function redirectTo(Request $request): ?string
     {
-        return $request->expectsJson() ? null : route('login');
+        // return $request->expectsJson() ? null : route('login');
+        return $request->expectsJson() ? null : url('login');
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -53,6 +53,8 @@ Route::post('/logout', [AuthController::class, 'logout']);
 // ログイン動作確認用のページです。最後には消します。
 Route::get('/login-test', function () {
     return view('auth.login-test');
-})->middleware('auth'); // このmiddleware(auth)を付けるとログイン中専用のページになります。あとで月森が付けていきます。説明もします。
-// この時にでるエラーは後で対応します！
+})->middleware('auth');
+
+
+
 


### PR DESCRIPTION
@sirowabisuke @enmusubi22 @hnk2326 
レビューお願いします！

動作にほぼ変更がないので動作確認は要らないと思います。
たぶんコンフリクトも起きないと思います。

- UserRegisterController.php でアカウント登録後にそのままログインするようにしました。

- その他は認証機能で認証でNGが出た際の画面遷移が上手くいってなかった箇所の修正です。 
- web.php　：　メモしてたエラーが解消したのでコメント１行削除
- AuthController.php　：　ログイン失敗した後の画面遷移が変だったのを修正
- UserRegisterController.php：１行書きもらしを修正。アカウント登録したらそのままログインされるようになります。
- Authenticate.php：Laravel標準の認証用ファイル。ログアウト中に開けないページを開いたときに、正しい画面に遷移されてなかったエラーの解消。
