### PR TITLE
category_idのNULLエラー解消

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -124,7 +124,7 @@ class ItemController extends Controller
         // 既存の商品情報を取得して、編集内容を保存し一覧画面に戻る
         $item = Item::find($id);
 
-        $item->user_id = 1; // 最終的にはログインユーザーのIDが入るようにする
+        $item->user_id = 1;
         $item->date = $request->date;
         $item->item_name = $request->item_name;
         $item->category_id = $request->category_id;

--- a/database/migrations/2025_02_27_143129_create_items_table.php
+++ b/database/migrations/2025_02_27_143129_create_items_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('items', function (Blueprint $table) {
             $table->id()->autoIncrement()->unsigned();	
-            $table->biginteger('category_id')->unsigned()->index();	
+            $table->biginteger('category_id')->unsigned()->index()->nullable();	
             $table->biginteger('user_id')->unsigned()->index();	
             $table->date('date');	
             $table->string('item_name', 100);	

--- a/resources/views/items/create.blade.php
+++ b/resources/views/items/create.blade.php
@@ -26,7 +26,7 @@
                     <option value="1">1</option>
                     <option value="2">2</option>
                     <option value="3">3</option>
-                    <option value="3">3</option>
+                    <option value="4">4</option>
                 </select>
             </div>
 

--- a/resources/views/items/edit.blade.php
+++ b/resources/views/items/edit.blade.php
@@ -26,6 +26,7 @@
                     <option value="1" {{ old('category_id', $item->category_id) == 1 ? 'selected' : '' }}>1</option>
                     <option value="2" {{ old('category_id', $item->category_id) == 2 ? 'selected' : '' }}>2</option>
                     <option value="3" {{ old('category_id', $item->category_id) == 3 ? 'selected' : '' }}>3</option>
+                    <option value="4" {{ old('category_id', $item->category_id) == 4 ? 'selected' : '' }}>4</option>
                 </select>
             </div>
 


### PR DESCRIPTION
@sirowabisuke @enmusubi22 @hiroshi-t-1400 
category_idがNULLの場合に発生するエラーを解消しました。
また、カテゴリ選択の画面で1~3しか選べなかったところを1~4に修正、
3が2つ存在して4がなかったところを1~4に修正しました。