### PR TITLE
ログイン、アカウント登録エラー表示の修正

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -21,24 +21,12 @@
                 <div class="alert alert-danger">
                     <ul class="error-msg-list">
                         @foreach ($errors->all() as $error)
-                        <li>{{ $error }}</li>
+                        <li >{{ $error }}</li>
                         @endforeach
                     </ul>
                 </div>
             @endif
-            <!-- ここまで　ログインエラー -->
-
-
-        {{-- <!-- みんなが慣れてきたら消します！！ -->
-        <p class="skip-login-cheat alert alert-warning"><b>
-            <span class="bg-info">あとで必ず消します！</span> <br>
-                        ログインの手間が面倒なので、しばらく最初からログイン情報をフォームにいれています。<br>
-                        user: taro@example.com <br>
-                        password: taropass <br>
-            <span class="bg-info">あとで必ず消します！</span>
-        </b></p>
-        <!-- ここまで　消します！！ --> --}}
-
+                <!-- ここまで　ログインエラー -->
 
         <!-- ログイン用のフォームを設置 -->
         <div class="input-form-wrapper w-50 mx-auto row">
@@ -48,11 +36,17 @@
                 <div class="mb-4">
                     <label for="email" class="form-label">メールアドレス</label>
                     <input id="email" type="email" name="email" class="w-100 border-secondary form-control" placeholder="" value="{{ old('email') }}" autofocus>
+                    @error('email')
+                        <div class="text-danger">{{ $message }}</div>
+                    @enderror
                 </div>
 
                 <div class="mb-4">
                     <label for="password" class="form-label">パスワード</label>
                     <input id="password" type="password" name="password" class="w-100 border-secondary form-control" placeholder="" value="">
+                    @error('password')
+                        <div class="text-danger">{{ $message }}</div>
+                    @enderror
                 </div>
 
                 <div class="login-btn-wrapper py-2 d-grid d-md-flex justify-content-md-center">

--- a/resources/views/users/user-register.blade.php
+++ b/resources/views/users/user-register.blade.php
@@ -10,33 +10,15 @@
         UserRegisterControllerから送られてきた &errorsの中身があれば表示する
         all() でforeachで使える形にして $error １つずつ格納して全て表示する --}}
         @if ($errors->any())
-        <div class="alert">
-            <ul class="error-msg-list">
-                @foreach ($errors->all() as $error)
-                <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
+            <div class="alert alert-danger">
+                <ul class="error-msg-list">
+                    @foreach ($errors->all() as $error)
+                    <li >{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
         @endif
         {{-- ここまで アカウント登録エラー --}}
-
-        {{--
-        みんなが慣れてきたら消します！！
-        <p class="skip-login-cheat alert alert-warning"><b>
-            <span class="bg-info">あとで必ず消します！</span> <br>
-            <span class="for-error" style="display:inline-block; border:solid red; font-size:80%;">
-                「The email has already been taken.」エラーについて<br>
-                メールアドレスでユーザーを識別しているので、メールアドレスをダブらないように変更してみてください。
-            </span>
-            <br>
-            文字入力の手間が面倒なので、しばらく最初からログイン情報をフォームにいれています。<br>
-            name: たろう<br>
-            user: taro@example.com <br>
-            password: taropass <br>
-            <span class="bg-info">あとで必ず消します！</span>
-        </b></p>
-        ここまで　消します！！ --}}
-
 
         {{-- アカウント作成用のフォームを設置 --}}
         <div class="input-form-wrapper w-50 mx-auto">
@@ -46,24 +28,37 @@
                 {{-- 名前：name --}}
                 <div class="mb-4">
                     <label for="name" class="form-label">名前</label>
-                    <input id="name" type="text" name="name" class="w-100 border-secondary form-control" placeholder="" value="{{ old('name') }}" autofocus>
+                    <input id="name" type="text" name="name" class="w-100 border-secondary form-control" value="{{ old('name') }}" autofocus>
+                    @error('name')
+                        <div class="text-danger">{{ $message }}</div>
+                    @enderror
                 </div>
 
                 {{-- メールアドレス：mail --}}
                 <div class="mb-4">
                     <label for="email" class="form-label">メールアドレス</label>
-                    <input id="email" type="email" name="email" class="w-100 border-secondary form-control" placeholder="" value="{{ old('email') }}">
+                    <input id="email" type="email" name="email" class="w-100 border-secondary form-control" value="{{ old('email') }}">
+                    @error('email')
+                        <div class="text-danger">{{ $message }}</div>
+                    @enderror
                 </div>
 
                 {{-- パスワード：password，password_confirmation --}}
                 <div class="mb-4">
                     <label for="password" class="form-label">パスワード</label>
                     <span class="small text-secondary ms-3">※８文字～１６文字</span>
-                    <input id="password" type="password" name="password" class="w-100 border-secondary form-control" placeholder="" value="">
+                    <input id="password" type="password" name="password" class="w-100 border-secondary form-control" value="">
+                    @error('password')
+                    <div class="text-danger">{{ $message }}</div>
+                    @enderror
                 </div>
+
                 <div class="mb-4">
                     <label for="password-conf">パスワード（確認）</label>
-                    <input id="password-conf" type="password" name="password_confirmation" class="w-100 border-secondary form-control" placeholder="" value="">
+                    <input id="password-conf" type="password" name="password_confirmation" class="w-100 border-secondary form-control" value="">
+                    @error('password_confirmation')
+                    <div class="text-danger">{{ $message }}</div>
+                    @enderror
                 </div>
 
                 {{-- 管理者権限付与：role --}}
@@ -84,6 +79,6 @@
                     <a href="{{ url('login') }}" class="d-block text-center w-100 m-2 mx-lg-3">キャンセル</a>
                 </div>
             </form>
-            
+
         </div>
 @endsection


### PR DESCRIPTION
@sirowabisuke @enmusubi22 @hnk2326 
レビューとマージよろしくお願いします。

ログイン画面とアカウント登録画面のエラー表示を整えました。
・エラーメッセージの一覧（総括・サーマリー）を赤枠で囲む。
・メールアドレスなど各項目の近くにもエラーメッセージを表示。
軽微な修正です。ログイン、アカウント登録画面は一応完成です。